### PR TITLE
Add property management to frontend and restrict API

### DIFF
--- a/aristay_backend/api/views.py
+++ b/aristay_backend/api/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.utils import timezone
 import json
 
@@ -6,15 +7,19 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.permissions import AllowAny  # Import AllowAny
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAdminUser
 
-from django.contrib.auth.models import User
-from .serializers import UserRegistrationSerializer
+
 from .models import Task
 from .models import Property
+
 from .serializers import TaskSerializer
 from .serializers import PropertySerializer
-from .permissions import IsOwnerOrAssignedOrReadOnly  # Import our custom permission
 from .serializers import UserSerializer
+from .serializers import UserRegistrationSerializer
+
+
+from .permissions import IsOwnerOrAssignedOrReadOnly  # Import our custom permission
 
 class UserRegistrationView(generics.CreateAPIView):
     queryset = User.objects.all()
@@ -74,8 +79,8 @@ class TaskDetail(generics.RetrieveUpdateDestroyAPIView):
 class PropertyListCreate(generics.ListCreateAPIView):
     queryset = Property.objects.all()
     serializer_class = PropertySerializer
-    permission_classes = [IsAuthenticated]
-    
+    permission_classes = [IsAdminUser]
+        
 class UserList(generics.ListAPIView):
     """
     Lists all users (id + username), so the front end can

--- a/aristay_flutter_frontend/lib/main.dart
+++ b/aristay_flutter_frontend/lib/main.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'models/task.dart';
+import 'models/property.dart';
+
 import 'screens/login_screen.dart';
 import 'screens/home_screen.dart';
 import 'screens/task_list_screen.dart';
 import 'screens/task_form_screen.dart';
 import 'screens/edit_task_screen.dart';
 import 'screens/task_detail_screen.dart';
+import 'screens/property_list_screen.dart';
+import 'screens/property_form_screen.dart';
 
 void main() => runApp(const MyApp());
 
@@ -21,6 +25,12 @@ class MyApp extends StatelessWidget {
         '/': (c) => const LoginScreen(),
         '/home': (c) => const HomeScreen(),
         '/tasks': (c) => const TaskListScreen(),
+        '/properties': (c) => const PropertyListScreen(),
+        '/properties/new': (c) => const PropertyFormScreen(),
+        '/properties/edit': (c) {
+          final prop = ModalRoute.of(c)!.settings.arguments as Property;
+          return PropertyFormScreen(property: prop);
+        },
         '/create-task': (c) => const TaskFormScreen(),
         '/edit-task': (c) {
           final task = ModalRoute.of(c)!.settings.arguments as Task;
@@ -28,7 +38,6 @@ class MyApp extends StatelessWidget {
         },
         '/task-detail': (c) {
           final task = ModalRoute.of(c)!.settings.arguments as Task;
-          // change here: use initialTask named parameter
           return TaskDetailScreen(initialTask: task);
         },
       },

--- a/aristay_flutter_frontend/lib/screens/home_screen.dart
+++ b/aristay_flutter_frontend/lib/screens/home_screen.dart
@@ -19,12 +19,18 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(height: 16),
             ElevatedButton(
               onPressed: () async {
-                final created = await Navigator.pushNamed(context, '/create-task');
+                final created =
+                    await Navigator.pushNamed(context, '/create-task');
                 if (created == true) {
                   Navigator.pushReplacementNamed(context, '/tasks');
                 }
               },
               child: const Text('Create New Task'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.pushNamed(context, '/properties'),
+              child: const Text('Manage Properties'),
             ),
           ],
         ),

--- a/aristay_flutter_frontend/lib/screens/property_form_screen.dart
+++ b/aristay_flutter_frontend/lib/screens/property_form_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../models/property.dart';
+import '../services/api_service.dart';
+
+class PropertyFormScreen extends StatefulWidget {
+  final Property? property;
+  const PropertyFormScreen({Key? key, this.property}) : super(key: key);
+
+  @override
+  State<PropertyFormScreen> createState() => _PropertyFormScreenState();
+}
+
+class _PropertyFormScreenState extends State<PropertyFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameCtrl = TextEditingController();
+  bool _loading = false, _error = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.property != null) {
+      _nameCtrl.text = widget.property!.name;
+    }
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() {
+      _loading = true;
+      _error = false;
+    });
+
+    final payload = {'name': _nameCtrl.text.trim()};
+    final api = ApiService();
+    final ok = widget.property == null
+        ? await api.createProperty(payload)
+        : await api.updateProperty(widget.property!.id, payload);
+
+    if (ok) {
+      Navigator.pop(context, true);
+    } else {
+      setState(() => _error = true);
+    }
+
+    setState(() => _loading = false);
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEdit = widget.property != null;
+    return Scaffold(
+      appBar: AppBar(title: Text(isEdit ? 'Edit Property' : 'New Property')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nameCtrl,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (v) =>
+                    (v ?? '').trim().isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 24),
+              if (_error)
+                const Text('Save failed',
+                    style: TextStyle(color: Colors.red)),
+              _loading
+                  ? const CircularProgressIndicator()
+                  : ElevatedButton(
+                      onPressed: _save,
+                      child: Text(isEdit ? 'Update' : 'Create'),
+                    ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/aristay_flutter_frontend/lib/screens/property_list_screen.dart
+++ b/aristay_flutter_frontend/lib/screens/property_list_screen.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import '../models/property.dart';
+import '../services/api_service.dart';
+
+class PropertyListScreen extends StatefulWidget {
+  const PropertyListScreen({Key? key}) : super(key: key);
+
+  @override
+  State<PropertyListScreen> createState() => _PropertyListScreenState();
+}
+
+class _PropertyListScreenState extends State<PropertyListScreen> {
+  final ApiService _api = ApiService();
+  List<Property> _items = [];
+  bool _loading = false, _error = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    try {
+      _items = await _api.fetchProperties();
+      _error = false;
+    } catch (_) {
+      _error = true;
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _delete(Property p) async {
+    final ok = await _api.deleteProperty(p.id);
+    if (ok) {
+      await _load();
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Delete failed')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Properties')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error
+              ? const Center(child: Text('Failed to load properties'))
+              : ListView.builder(
+                  itemCount: _items.length,
+                  itemBuilder: (ctx, i) {
+                    final p = _items[i];
+                    return ListTile(
+                      title: Text(p.name),
+                      trailing: PopupMenuButton<String>(
+                        onSelected: (v) {
+                          if (v == 'edit') {
+                            Navigator.pushNamed(
+                              context,
+                              '/properties/edit',
+                              arguments: p,
+                            ).then((_) => _load());
+                          } else if (v == 'del') {
+                            _delete(p);
+                          }
+                        },
+                        itemBuilder: (_) => const [
+                          PopupMenuItem(value: 'edit', child: Text('Edit')),
+                          PopupMenuItem(value: 'del', child: Text('Delete')),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.pushNamed(context, '/properties/new')
+              .then((_) => _load());
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/aristay_flutter_frontend/lib/services/api_service.dart
+++ b/aristay_flutter_frontend/lib/services/api_service.dart
@@ -24,6 +24,51 @@ class ApiService {
     final raw = body is List ? body : (body['results'] as List<dynamic>);
     return raw.map((e) => Property.fromJson(e as Map<String, dynamic>)).toList();
   }
+  
+  /// Create a new property
+  Future<bool> createProperty(Map<String, dynamic> payload) async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('auth_token');
+    if (token == null) throw Exception('No auth token found');
+    final res = await http.post(
+      Uri.parse('$baseUrl/properties/'),
+      headers: {
+        'Authorization': 'Token $token',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(payload),
+    );
+    return res.statusCode == 201 || res.statusCode == 200;
+  }
+
+  /// Update an existing property
+  Future<bool> updateProperty(int id, Map<String, dynamic> payload) async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('auth_token');
+    if (token == null) throw Exception('No auth token found');
+    final res = await http.patch(
+      Uri.parse('$baseUrl/properties/$id/'),
+      headers: {
+        'Authorization': 'Token $token',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(payload),
+    );
+    return res.statusCode == 200;
+  }
+
+  /// Delete a property
+  Future<bool> deleteProperty(int id) async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('auth_token');
+    if (token == null) throw Exception('No auth token found');
+    final res = await http.delete(
+      Uri.parse('$baseUrl/properties/$id/'),
+      headers: {'Authorization': 'Token $token'},
+    );
+    return res.statusCode == 204;
+  }
+
   Future<Task> fetchTask(int id) async {
     final prefs = await SharedPreferences.getInstance();
     final token = prefs.getString('auth_token');


### PR DESCRIPTION
Introduces property list and form screens to the Flutter frontend, enabling admins to create, edit, and delete properties. Updates the API to restrict property creation and listing to admin users only. Adds corresponding API service methods for property CRUD operations and integrates property management into the home screen navigation.