### PR TITLE
Disable pagination for PropertyListCreate view

### DIFF
--- a/aristay_backend/api/views.py
+++ b/aristay_backend/api/views.py
@@ -80,6 +80,7 @@ class PropertyListCreate(generics.ListCreateAPIView):
     queryset = Property.objects.all()
     serializer_class = PropertySerializer
     permission_classes = [IsAdminUser]
+    pagination_class = None
         
 class UserList(generics.ListAPIView):
     """


### PR DESCRIPTION
Set pagination_class to None in PropertyListCreate to return all properties without pagination. This change ensures the API returns the full list of properties in a single response.