### PR TITLE
Run secret scan on all branches

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,7 +1,7 @@
 name: Secret Scan
 on:
   push:
-    branches: [ main, master ]
+    branches: [ "**" ]
   pull_request:
 
 permissions:


### PR DESCRIPTION
Updated the GitHub Actions workflow to trigger secret scanning on pushes to any branch, instead of only 'main' and 'master'. This ensures broader coverage and improved security monitoring.