### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Aristay CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Lambert-Nguyen/aristay_app/security/code-scanning/1](https://github.com/Lambert-Nguyen/aristay_app/security/code-scanning/1)

The best fix is to add an explicit top-level (or job-level) `permissions` block to `.github/workflows/ci.yml` specifying the minimum required privileges. In this case, as the workflow only needs to check out code, run tests, and upload artifacts, the minimal starting point is `contents: read`. This protects against accidental privilege escalation and ensures the workflow runs with least privilege.

- Change: Add `permissions: contents: read` at the top level, immediately below the `name:` or just above `jobs:`.  
- File: `.github/workflows/ci.yml`  
- No new imports, methods, or definitions needed—just a single YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
